### PR TITLE
correct superfluous meta charset

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,4 +1,3 @@
-<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="chrome=1">
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
Hello.  `meta charset` is declared in the head partial and again in the meta partial.