### PR TITLE
hide email button if the field is unset in the config

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,11 +35,13 @@
         </span>
       </a>
       {{ end }}
+      {{ with $.Site.Params.email }}
       <a class="navbar-item" href="mailto:{{ .Site.Params.email }}" target="_blank">
         <span class="icon">
           <img alt="email" src='{{ (resources.Get "icons/svg/email.svg").Permalink }}'>
         </span>
       </a>
+      {{ end }}
       {{ with $.Site.Home.OutputFormats.Get "rss" -}}
       <a class="navbar-item" href="{{ .Permalink }}" target="_blank">
         <span class="icon">


### PR DESCRIPTION
Currently, the email button is shown, even if the field is not set in the config. In this PR, the button is conditionally hidden.