### PR TITLE
sass: body flex display

### DIFF
--- a/assets/css/site.sass
+++ b/assets/css/site.sass
@@ -2,6 +2,13 @@
 // Include just the Bulma elements we require.
 @import "bulma/bulma"
 
+html, body
+  height: 100%
+
+body
+  display: flex
+  flex-direction: column
+
 .content
   word-break: break-word
 
@@ -27,7 +34,7 @@
 .is-medium
   pre
     font-size: $size-normal
-    
+
 .no-margin
   margin-left: 0
   margin-right: 0


### PR DESCRIPTION
This PR allows the footer to always be shown at the bottom of the screen, even when the content/body is shorter.

- Current layout: https://hugo-bare-theme.netlify.app/
- With this PR (note that the height of the footer is also changed): https://vhdl.github.io/news/