### PR TITLE
Example site: remove shortcode instagram_simple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ hugo.darwin
 hugo.linux
 node_modules/
 .idea/
-exampleSite/resources/
-exampleSite/public/

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+.hugo_build.lock
+public/
+resources/

--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -13,14 +13,6 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 <!--more-->
 ---
 
-## Instagram Simple Shortcode
-
-{{< instagram_simple BGvuInzyFAe hidecaption >}}
-
-<br>
-
----
-
 ## YouTube Privacy Enhanced Shortcode
 
 {{< youtube ZJthWmvUzzc >}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.. -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.67.1"
+  HUGO_VERSION = "0.93.1"
   HUGO_ENV = "production"
   HUGO_THEME = "repo"
 


### PR DESCRIPTION
With latest hugo version `0.93.0`, preview of example site fails due to shortcode `instagram_simple`:

```
$ hugo server --themesDir ../../
Start building sites …
hugo v0.93.1-E9669FED+extended windows/amd64 BuildDate=2022-03-02T12:16:07Z VendorInfo=gohugoio
ERROR 2022/03/04 12:33:19 instagram shortcode: Missing config value for services.instagram.accessToken.
This can be set in config.toml, but it is recommended to configure this via the HUGO_SERVICES_INSTAGRAM_ACCESSTOKEN
OS environment variable. If you are using a Client Access Token, remember that you must combine it with your App ID
using a pipe symbol (<APPID>|<CLIENTTOKEN>) otherwise the request will fail.
If you feel that this should not be logged as an ERROR, you can ignore it by adding this to your site config:
ignoreErrors = ["error-missing-instagram-accesstoken"]
```

This shortcode uses a deprecated API, see this [issue](https://github.com/gohugoio/hugo/issues/7879#issuecomment-716058575) for details.

Since this shortcode doesn't work on the [official preview site](https://hugo-bare-theme.netlify.app/post/rich-content/) of the theme either, I removed the shortcode.